### PR TITLE
Fix population in study definition

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -41,9 +41,9 @@ study = StudyDefinition(
     """
       registered
       AND
-      age >= 2 AND age <=120
+      (age >= 2 AND age <= 120)
       AND
-      sex = "M" OR sex = "F" 
+      (sex = "M" OR sex = "F")
       AND
       NOT has_died
       AND 


### PR DESCRIPTION
@evansd and I had a closer look at the study definition and found something that looks like a bug. Currently there are no parentheses around `sex = "M" OR sex = "F"` and the `AND` operator naturally takes precedence so the condition is interpreted as: 

```
(
      registered
      AND
      age >= 2 AND age <=120
      AND
      sex = "M"
)
OR
(
      sex = "F" 
      AND
      NOT has_died
      AND 
      NOT ((care_home_tpp="care_or_nursing_home") OR (care_home_code))
      AND 
      msoa
)
```

This PR should fix that problem but it looks like you need to rerun all actions. For clarity I also added parentheses to the age condition `(age >= 2 AND age <=120)` although this is identical and not necessary. 